### PR TITLE
Changed wording, payments made => payments issued

### DIFF
--- a/locales/en/schedule.json
+++ b/locales/en/schedule.json
@@ -39,13 +39,13 @@
   "bankName": "Bank name",
   "inBank": "Payments were paid to account number {{accountNumber}}",
   "toBank": "Payments will be paid to account number {{accountNumber}}",
-  "pastPayments": "Payments made",
+  "pastPayments": "Payments issued",
   "overpayments": "Overpayments",
   "futurePayments": "Payments due",
   "paymentsStopped": "Payments prevented",
   "paymentsStoppedMsg": "Payments stopped {{-timeStart}}{{date}}{{-timeStop}}",
-  "noPaymentsMade": "No payments made.",
-  "allPaymentsMade": "All payments made.",
+  "noPaymentsMade": "No payments issued.",
+  "allPaymentsMade": "All payments issued.",
   "await": {
     "error": "An error occurred while requesting schedule data.",
     "timeout": "Request for schedule data timed out."


### PR DESCRIPTION
Change the wording on the schedule for 'payments made', replacing all instances to 'issued' instead. The reasons for this, was that we cant guarantee that the payment was actually made, but we can guarantee that it was actually issued. Payments made might confuse the agents into thinking this means the claimant should actually have the money, when something went wrong outside of the schedule view.